### PR TITLE
Support any default branch name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ https://bitbucket.org/user/repo
 fn download(repo: Repo, dest: PathBuf) -> Result<(), Box<dyn Error>> {
     let url = match &repo.host {
         Host::Github => format!(
-            "https://github.com/{}/{}/archive/master.tar.gz",
+            "https://github.com/{}/{}/archive/HEAD.tar.gz",
             repo.owner, repo.project
         ),
         Host::Gitlab(x) => format!(
@@ -106,7 +106,7 @@ fn download(repo: Repo, dest: PathBuf) -> Result<(), Box<dyn Error>> {
             x, repo.owner, repo.project
         ),
         Host::BitBucket => format!(
-            "https://bitbucket.org/{}/{}/get/master.zip",
+            "https://bitbucket.org/{}/{}/get/HEAD.zip",
             repo.owner, repo.project
         ),
     };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -38,6 +38,23 @@ fn github() {
     assert_eq!(download(repo, PathBuf::from("/tmp/tests")).unwrap(), ());
 }
 #[test]
+fn github_main() {
+    let repo = Repo {
+        host: Host::Github,
+        owner: "octocat".to_string(),
+        project: "Spoon-Knife".to_string(),
+    };
+
+    assert_eq!(parse("octocat/Spoon-Knife").unwrap(), repo);
+    assert_eq!(parse("github:octocat/Spoon-Knife").unwrap(), repo);
+    assert_eq!(
+        parse("https://github.com/octocat/Spoon-Knife.git").unwrap(),
+        repo
+    );
+    assert_eq!(parse("git@github.com:octocat/Spoon-Knife.git").unwrap(), repo);
+    assert_eq!(download(repo, PathBuf::from("/tmp/tests")).unwrap(), ());
+}
+#[test]
 fn gitlab_hosted() {
     let repo = Repo {
         host: Host::Gitlab("gitlab.gnome.org".to_string()),


### PR DESCRIPTION
Replace hard coded references of `master` branch to `HEAD`.  Adds support for other default branches such as `main`.